### PR TITLE
corrected bug on Mac in build-c because 'win' not only matches Windows machines …

### DIFF
--- a/tools/cocoutils.py
+++ b/tools/cocoutils.py
@@ -140,7 +140,8 @@ def make(directory, target):
     try:
         os.chdir(directory)
         # prepare makefile(s)
-        if ('win' in sys.platform) and ('cygwin' not in os.environ['PATH']):
+        if ((('win32' in sys.platform) or ('win64' in sys.platform)) and
+            ('cygwin' not in os.environ['PATH'])):
             # only if under Windows and without Cygwin, we need a specific
             # Windows makefile
             copy_file('Makefile_win_gcc.in', 'Makefile')


### PR DESCRIPTION
…but also for example 'darwin'